### PR TITLE
compile using c++98

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(safe_footstep_planner)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp


### PR DESCRIPTION
闇の深そうな問題のため，とりあえずc++98にさせて下さい．

---------
https://github.com/yuki-shark/safe_footstep_planner/blob/jaxonred/src/target_height_publisher.cpp#L118
がソースのどこかにあると
ubuntu14.04 + c++11以上 の組み合わせのとき，実行時にセグフォる．
謎なのが，コンパイルはできて実行時に起こる問題なのに，
実行時のTargetHeightPublisherのインスタンスつくるよりも前(main関数すらも呼ばれる前)に落ちる．

@kyawawa @future731 @epsilonkei